### PR TITLE
Support wraparound movement near the edges

### DIFF
--- a/Assets/Scripts/PlayerBase.cs
+++ b/Assets/Scripts/PlayerBase.cs
@@ -14,6 +14,13 @@ public class PlayerBase : MonoBehaviour
     private float m_xChange;
     private bool m_isJumping;
 
+    // [PN] TODO: make these constraints flexible depending on stage
+    private const float leftConstraint = -9.4f;
+    private const float rightConstraint = 9.4f;
+    private const float bottomConstraint = -4.6f;
+    private const float topConstraint = 4.6f;
+    private const float buffer = 0.1f;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -25,6 +32,7 @@ public class PlayerBase : MonoBehaviour
     void Update()
     {
         this.handleMovement();
+        this.handleWraparound();
     }
 
     protected void handleMovement() {
@@ -39,6 +47,22 @@ public class PlayerBase : MonoBehaviour
             rb.velocity = Vector2.up * jumpVelocity;
             this.grounded = false;
             this.m_isJumping = false;
+        }
+    }
+
+    private void handleWraparound() {
+        // Handle wraparound on the x-axis
+        if (transform.position.x < leftConstraint - buffer) {
+            transform.position = new Vector3(rightConstraint + buffer,transform.position.y, transform.position.z);
+        } else if (transform.position.x > rightConstraint + buffer) {
+            transform.position = new Vector3(leftConstraint - buffer,transform.position.y, transform.position.z);
+        }
+
+        // Handle wraparound on the y-axis
+        if (transform.position.y < bottomConstraint - buffer) {
+            transform.position = new Vector3(transform.position.x, topConstraint + buffer, transform.position.z);
+        } else if (transform.position.y > topConstraint + buffer) {
+            transform.position = new Vector3(transform.position.x, bottomConstraint - buffer, transform.position.z);
         }
     }
 


### PR DESCRIPTION
This PR makes it so if the player moves near the edge of the screen, it takes the player to the other side of the screen similar to a barrel.

Some thoughts:
* I'd like to make this be able to scale to any map size so that we don't need to measure out the edges like I did here, but I didn't know how to get the boundaries of a Scene
* It would also be cool to have partial rendering when the player peaks out near the edge. Currently it will transport the player completely, which is fine if the player is moving quickly, but can be jarring if it's slower movement