### PR TITLE
Jump attack and death

### DIFF
--- a/Assets/Levels.meta
+++ b/Assets/Levels.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fddc96f81dd2940b181634d9822caae1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -143,7 +143,7 @@ Rigidbody2D:
   m_Material: {fileID: 0}
   m_Interpolate: 0
   m_SleepingMode: 1
-  m_CollisionDetection: 0
+  m_CollisionDetection: 1
   m_Constraints: 4
 --- !u!114 &5984261576749040459
 MonoBehaviour:

--- a/Assets/Scripts/PlayerBase.cs
+++ b/Assets/Scripts/PlayerBase.cs
@@ -7,6 +7,7 @@ public class PlayerBase : MonoBehaviour
 {
     private Rigidbody2D rb;
     private bool grounded;
+    private int hitpoints;
 
     public float horizontalMovementModifier;
     public float jumpVelocity;
@@ -28,6 +29,7 @@ public class PlayerBase : MonoBehaviour
     {
         this.rb = this.GetComponent<Rigidbody2D>();
         this.grounded = false;
+        this.hitpoints = 3;
         spawns = GameObject.FindGameObjectsWithTag("Respawn");
 
         int index = Random.Range(0, spawns.Length);
@@ -40,6 +42,7 @@ public class PlayerBase : MonoBehaviour
     {
         this.handleMovement();
         this.handleWraparound();
+        this.handleDeath();
     }
 
     protected void handleMovement() {
@@ -78,6 +81,12 @@ public class PlayerBase : MonoBehaviour
         }
     }
 
+    private void handleDeath() {
+        if (this.hitpoints <= 0) {
+            this.Die();
+        }
+    }
+
     private void OnMove(InputValue value) {
         this.m_xChange = value.Get<Vector2>().x;
     }
@@ -91,14 +100,26 @@ public class PlayerBase : MonoBehaviour
     }
 
     public void Die() {
+        Destroy(gameObject);
         Destroy(this);
+        // Add some other handlers here
     }
 
     private void OnCollisionEnter2D(Collision2D other) {
         // TODO: more consistent raycast logic needed
-        RaycastHit2D hit = Physics2D.Raycast(transform.position, Vector2.down, 0.6f);
-        if (hit.collider != null) {
-            this.grounded = true;
+        RaycastHit2D downwardhit = Physics2D.Raycast(transform.position, Vector2.down, 0.6f);
+        RaycastHit2D upwardHit = Physics2D.Raycast(transform.position, Vector2.up, 0.6f);
+        if (downwardhit.collider != null) {
+            if (downwardhit.collider.tag == "Player") {
+                rb.velocity = Vector2.up * jumpVelocity;
+            } else {
+                this.grounded = true;
+            }
+        }
+        if (upwardHit.collider != null) {
+            if (upwardHit.collider.tag == "Player") {
+                this.hitpoints -= 1;
+            }
         }
     }
 }


### PR DESCRIPTION
When players jump on other players, do damage. Players start out with 3 HP and if it is brought down to 0, the object is removed. We might want to have some sort of death animation and use the timed Destroy instead.

I feel like the way this is implemented is a little weird because it requires the Player to be aware of other objects doing damage to it and subtract that damage from its own HP. I think ideally we'd have some event to broadcast (e.g. OnHit), letting listeners be aware that they've been hit and having the aggressor specify how much damage to do. This way, we can specify differing amounts of damage depending on the damage source and have that number be tied to the damage source instead of the receiver.

This accomplishes our goal for now but I do want to revisit this since we'll need to think about different objects interacting with the Player and I think it would be easier to reason about in the approach described earlier.