### PR TITLE
Adjust movement

### DIFF
--- a/Assets/Prefabs/PlayerAvatar.prefab
+++ b/Assets/Prefabs/PlayerAvatar.prefab
@@ -139,7 +139,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 2748129442280046358, guid: 8a22d558e08c5fa43a64f691732a9869,
+  m_Sprite: {fileID: 5766576628905575391, guid: 4fad312ba1e9e4dbca15fd01992a5bdb,
     type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -230,6 +230,6 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
+  m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0

--- a/Assets/Prefabs/PlayerAvatar.prefab
+++ b/Assets/Prefabs/PlayerAvatar.prefab
@@ -47,8 +47,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 039327eb30236b94da9e5b4421b5f571, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  horizontalMovementModifier: 15
-  jumpVelocity: 7.5
+  groundSpeed: 50
+  jumpHeight: 2
+  airAcceleration: 10
+  walkAcceleration: 15
+  airDeceleration: 1
+  groundDeceleration: 10
 --- !u!61 &5984261576749040458
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/PlayerAvatar.prefab
+++ b/Assets/Prefabs/PlayerAvatar.prefab
@@ -29,7 +29,7 @@ Transform:
   m_GameObject: {fileID: 5984261576749040460}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0.16505925, y: -0.184393, z: -0.017420297}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.9, y: 0.9, z: 1}
   m_Children:
   - {fileID: 1559282344139227822}
   m_Father: {fileID: 0}


### PR DESCRIPTION
This PR changes how we handle movement. Rather than simply translating position, we are now applying velocity and acceleration. This should make collision detection work better since we are no longer moving our player into locations it shouldn't be.

We also modify how we detect ground. Rather than RayCast from the center of the block and check to see if we hit another object, we use the built-in collision detection and check if we are touching the top side of a ground block. 

Side note: changed the sprite attached to the player because I couldn't load whatever sprite was attached to the player. 

https://recordit.co/zHQj5MYzMu