### PR TITLE
Applies formating on save for VSCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+### Format on Save
+
+We have configuration in place to format our C# code on save. If this does not work for you, check your VS Code settings:
+
+1. Go to Settings (the Keyboard shortcut for this is `Command` `,` for Mac users, and `Ctrl` `,` for Windows users. It can also be accessed through `File->Preferences->Settings`, or something similar)
+2. Search for "Format on Save", and check the box.
+
+[Source](https://code.visualstudio.com/docs/getstarted/settings) and [source](https://stackoverflow.com/questions/39494277/how-do-you-format-code-on-save-in-vs-code)

--- a/omnisharp.json
+++ b/omnisharp.json
@@ -1,0 +1,27 @@
+{
+    "FormattingOptions": {
+        "enableEditorConfigSupport": true,
+
+        "newLine": "\n",
+        "useTabs": false,
+        "tabSize": 4,
+        "indentationSize": 4,
+
+        "NewLinesForBracesInTypes": false,
+        "NewLinesForBracesInMethods": false,
+        "NewLinesForBracesInProperties": false,
+        "NewLinesForBracesInAccessors": false,
+        "NewLinesForBracesInAnonymousMethods": false,
+        "NewLinesForBracesInControlBlocks": false,
+        "NewLinesForBracesInAnonymousTypes": false,
+        "NewLinesForBracesInObjectCollectionArrayInitializers": false,
+        "NewLinesForBracesInLambdaExpressionBody": false,
+
+        "NewLineForElse": false,
+        "NewLineForCatch": false,
+        "NewLineForFinally": false,
+        "NewLineForMembersInObjectInit": false,
+        "NewLineForMembersInAnonymousTypes": false,
+        "NewLineForClausesInQuery": false
+    }
+}


### PR DESCRIPTION
Omnisharp is an extension that (I think) is added by default when using C# in VSCode. This leverages Omnisharp to format our code for us!