### PR TITLE
fix tilemap collision in build

### DIFF
--- a/Assets/Palettes/#2 - Transparent & Drop Shadow.png.meta
+++ b/Assets/Palettes/#2 - Transparent & Drop Shadow.png.meta
@@ -782,7 +782,7 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 32
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
-  spriteGenerateFallbackPhysicsShape: 0
+  spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
   spriteTessellationDetail: -1

--- a/Assets/Palettes/[32x32] Dungeon Bricks Shadow.png.meta
+++ b/Assets/Palettes/[32x32] Dungeon Bricks Shadow.png.meta
@@ -215,7 +215,7 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 32
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
-  spriteGenerateFallbackPhysicsShape: 0
+  spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
   spriteTessellationDetail: -1

--- a/Assets/Palettes/tmw_desert_spacing.png.meta
+++ b/Assets/Palettes/tmw_desert_spacing.png.meta
@@ -344,7 +344,7 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 32
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
-  spriteGenerateFallbackPhysicsShape: 0
+  spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
   spriteTessellationDetail: -1


### PR DESCRIPTION
Trello: https://trello.com/b/hmdxVEYb/gamedev

----

Collisions were working in when running the game within the Unity sandbox, but not in full builds.

It seems like we're hitting this issue:
https://forum.unity.com/threads/tilemap-collider-2d-doesnt-work-after-building-the-game.507218/

Doing the same fix described here (generating physics shapes from sprites) worked!
https://forum.unity.com/threads/tilemap-collider-2d-at-runtime.453533/#post-2938531
(see also: https://github.com/Unity-Technologies/2d-extras/issues/62#issuecomment-443158232)

NOTE: Collisions are WAAAY better, vs just falling in an infinite, ever
accelerating (portal-like) loop. However, there are still some wonky
collisions, e.g. if you jump it's possible to pass through the platforms
in some cases.
