### PR TITLE
fix wraparound bug

### DIFF
--- a/Assets/Scripts/Wraparound.cs
+++ b/Assets/Scripts/Wraparound.cs
@@ -3,7 +3,7 @@ using UnityEngine.Assertions;
 
 public class Wraparound : MonoBehaviour {
 
-    private const float wraparoundBuffer = 0.1f;
+    private const float wraparoundBuffer = 0.01f;
 
     private CompositeCollider2D cc;
 
@@ -22,11 +22,11 @@ public class Wraparound : MonoBehaviour {
             if (Mathf.Abs(colliderDistance.normal.x) > Mathf.Abs(colliderDistance.normal.y)) {
                 // wrap around horizontally
                 float buf = (wraparoundBuffer * Mathf.Sign(colliderDistance.normal.x));
-                other.transform.position = new Vector3(-1 * (p.x + buf), p.y, p.z);
+                other.transform.position = new Vector3(-1 * (p.x - buf), p.y, p.z);
             } else {
                 // wrap around vertically
                 float buf = wraparoundBuffer * Mathf.Sign(colliderDistance.normal.y);
-                other.transform.position = new Vector3(p.x, -1 * (p.y + buf), p.z);
+                other.transform.position = new Vector3(p.x, -1 * (p.y - buf), p.z);
             }
         }
     }


### PR DESCRIPTION
Before: The wraparound logic was pulling you slightly "out of bounds"
instead of pushing you back "in bounds". This meant that when you
wrapped around, it was possible to fall outside the level, because you
wouldn't retrigger the boundary.

Now: you shouldn't ever be able to get outside the boundary. The wraparound logic puts you inside the boundary. You should always hit the trigger and wraparound again.

--

![wraparound-bugfix](https://user-images.githubusercontent.com/102242/82988983-d3842480-9fae-11ea-94e4-5e02032d467e.gif)

_Gif of buggy behavior_