### PR TITLE
split test/build workflows. ship builds to itchio

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,8 @@
 name: Build
 
 on:
-  push: { branches: [master, itchio-autopublish] }
+  pull_request: {} # TODO: temp
+  push: { branches: [master] }
 
 env:
   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         uses: josephbmanley/butler-publish-itchio-action@v1.0.1
         env:
           BUTLER_CREDENTIALS: ${{ secrets.BUTLER_CREDENTIALS }}
-          CHANNEL: ${{matrix.targetPlatform}
+          CHANNEL: ${{ matrix.targetPlatform }}
           ITCH_GAME: cleverfall
           ITCH_USER: clevergamedev
-          PACKAGE: build/${{matrix.targetPlatform}}
+          PACKAGE: build/${{ matrix.targetPlatform }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,7 @@
 name: Build
 
 on:
-  pull_request: {} # TODO: temp
-  push: { branches: [master] }
+  push: { branches: [master, itchio-autopublish] }
 
 env:
   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,33 +1,12 @@
-name: Actions 😎
+name: Build
 
 on:
-  pull_request: {}
-  push: { branches: [master] }
+  push: { branches: [master, itchio-autopublish] }
 
 env:
   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
 
 jobs:
-  test:
-    name: Test ✨
-    runs-on: ubuntu-latest
-    steps:
-      # Checkout
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          lfs: true
-      # Cache
-      - uses: actions/cache@v1.1.2
-        with:
-          path: Library
-          key: Library
-
-      # Test
-      - name: Run tests
-        uses: webbertakken/unity-test-runner@v1.6
-        with:
-          unityVersion: 2019.3.0f6
   build:
     name: Build for ${{ matrix.targetPlatform }} on version ${{ matrix.unityVersion }}
     runs-on: ubuntu-latest
@@ -37,9 +16,9 @@ jobs:
         unityVersion:
           - 2019.3.0f6
         targetPlatform:
-          - StandaloneOSX # Build a macOS standalone (Intel 64-bit).
+          # - StandaloneOSX # Build a macOS standalone (Intel 64-bit).
           - StandaloneWindows64 # Build a Windows 64-bit standalone.
-          - WebGL # WebGL.
+          # - WebGL # WebGL.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -61,3 +40,11 @@ jobs:
         with:
           name: Build
           path: build
+      - name: Butler Push
+        uses: josephbmanley/butler-publish-itchio-action@v1.0.1
+        env:
+          BUTLER_CREDENTIALS: ${{ secrets.BUTLER_CREDENTIALS }}
+          CHANNEL: ${{matrix.targetPlatform}
+          ITCH_GAME: cleverfall
+          ITCH_USER: clevergamedev
+          PACKAGE: build/${{matrix.targetPlatform}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,9 @@ jobs:
         unityVersion:
           - 2019.3.0f6
         targetPlatform:
-          # - StandaloneOSX # Build a macOS standalone (Intel 64-bit).
+          - StandaloneOSX # Build a macOS standalone (Intel 64-bit).
           - StandaloneWindows64 # Build a Windows 64-bit standalone.
-          # - WebGL # WebGL.
+          - WebGL # WebGL.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build
 
 on:
-  push: { branches: [master, itchio-autopublish] }
+  push: { branches: [master] }
 
 env:
   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Actions 😎
+
+on:
+  pull_request: {}
+  push: { branches: [master] }
+
+env:
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+
+jobs:
+  test:
+    name: Test ✨
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+      # Cache
+      - uses: actions/cache@v1.1.2
+        with:
+          path: Library
+          key: Library
+
+      # Test
+      - name: Run tests
+        uses: webbertakken/unity-test-runner@v1.6
+        with:
+          unityVersion: 2019.3.0f6


### PR DESCRIPTION
- only run `test` on PRs
- on push (merge) to master, run `build` + `test`
- enhances `build` step to also include publishing builds to itch.io (https://clevergamedev.itch.io/cleverfall) ... this will give us a quicker feedback loop of being able to see the latest version in a web browser
