### PR TITLE
bugfix: normalize projectile velocity

### DIFF
--- a/Assets/Scripts/PlayerAvatar.cs
+++ b/Assets/Scripts/PlayerAvatar.cs
@@ -192,10 +192,11 @@ public class PlayerAvatar : MonoBehaviour {
     public void _onFire(InputValue value) {
         Vector3 projectilePos = transform.position;
         if (canFire) {
+            Vector2 direction = value.Get<Vector2>().normalized;
             // Don't spawn right on top of player
-            projectilePos += new Vector3(value.Get<Vector2>().x, value.Get<Vector2>().y, 0.0f);
+            projectilePos += (Vector3)direction;
             projectile = Instantiate(projectilePrefabs[this.m_weaponIndex], projectilePos, Quaternion.identity) as GameObject;
-            projectile.GetComponent<Projectile>().SetDirection(value.Get<Vector2>());
+            projectile.GetComponent<Projectile>().SetDirection(direction);
             projectile.GetComponent<Projectile>().SetOwner(this.GetComponent<PlayerAvatar>());
             StartCoroutine(waitForFireCooldown());
         }


### PR DESCRIPTION
When getting input from a keyboard (up/down/left/right), x and y were 0
or 1 values. However, the stick on a controller gave values like `(.1,
.3)`.

By normalizing the direction vector, we can ensure the offset and
velocity are predictable when using a controller.

https://trello.com/c/CKq7vIjx/67-fix-controller-sensitivity-when-shooting

![bugfix-projectile-velocity](https://user-images.githubusercontent.com/102242/86328296-7442b100-bbf9-11ea-9da4-173427d35647.gif)
_green is xbox controller, blue is keyboard_